### PR TITLE
Dp 1321

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Do **not** run these scripts on a machine that already has a PostgreSQL database
    - Launch `one-click.sh`
 
 3. **Answer interactive prompts**:
+   - Select container registry (default or custom)
    - Decide how to set up PostgreSQL (internal container or external DB)
    - Provide hostname
    - Confirm deployment
@@ -344,6 +345,164 @@ To migrate an existing IriusRisk on-prem installation to the new template-based 
   export TMPDIR=${XDG_RUNTIME_DIR}
   ```
   Log out and back in to pick this up.
+
+---
+
+## Container Registry Configuration
+
+The deployment supports both the default IriusRisk container registry and custom container registries.
+
+During installation you will be prompted to select the image source:
+
+1) Default IriusRisk registry  
+2) Custom registry
+
+### Default Registry
+
+If the default registry is selected, images are pulled from:
+
+docker.io/continuumsecurity/iriusrisk-prod
+
+Example images:
+
+docker.io/continuumsecurity/iriusrisk-prod:nginx  
+docker.io/continuumsecurity/iriusrisk-prod:tomcat-4  
+docker.io/continuumsecurity/iriusrisk-prod:startleft  
+docker.io/continuumsecurity/iriusrisk-prod:reporting-module
+
+### Custom Registry
+
+If a custom registry is selected, the installer will ask for:
+
+- Registry URL
+- Image repository path
+- Registry username
+- Registry password/token
+
+Example configuration:
+
+Registry URL:
+docker.io
+
+Repository path:
+myorg/iriusrisk-prod
+
+Images will then be resolved as:
+
+docker.io/myorg/iriusrisk-prod:nginx  
+docker.io/myorg/iriusrisk-prod:tomcat-4  
+docker.io/myorg/iriusrisk-prod:startleft  
+docker.io/myorg/iriusrisk-prod:reporting-module
+
+This allows organizations to mirror or host IriusRisk images in their own container registry.
+
+
+## Network Requirements
+
+For fully automated installation, the server must be able to access several external services.
+
+If your environment restricts outbound internet traffic, the following destinations must be allowed.
+
+### Git Repository
+
+Required to download the deployment templates.
+
+https://github.com  
+https://raw.githubusercontent.com
+
+Example usage:
+
+curl https://raw.githubusercontent.com/iriusrisk/onprem-templates/...  
+git clone https://github.com/iriusrisk/onprem-templates.git
+
+---
+
+### Container Registry
+
+Required to download IriusRisk container images.
+
+Default registry:
+
+docker.io  
+registry-1.docker.io  
+auth.docker.io
+
+Example images:
+
+docker.io/continuumsecurity/iriusrisk-prod:nginx  
+docker.io/continuumsecurity/iriusrisk-prod:tomcat-*  
+docker.io/continuumsecurity/iriusrisk-prod:startleft  
+docker.io/continuumsecurity/iriusrisk-prod:reporting-module
+
+If a custom registry is used, access must be allowed to that registry instead.
+
+---
+
+### OS Package Repositories
+
+The installer automatically installs required packages depending on the distribution.
+
+Typical repositories include:
+
+Ubuntu / Debian
+
+archive.ubuntu.com  
+security.ubuntu.com
+
+RHEL / Rocky / AlmaLinux
+
+dl.fedoraproject.org  
+mirrorlist.centos.org
+
+Amazon Linux
+
+amazonlinux.*.amazonaws.com
+
+---
+
+### PostgreSQL Image
+
+If internal PostgreSQL is used, the following image is downloaded:
+
+docker.io/library/postgres:15.4
+
+---
+
+### Optional External Services
+
+If you configure external PostgreSQL or custom container registries, network access must be allowed accordingly.
+
+---
+
+### Fully Air-Gapped Environments
+
+If outbound internet access is not allowed, deployment can still be performed by:
+
+- Mirroring container images in an internal registry
+- Cloning this repository internally
+- Using internal OS package mirrors
+
+---
+
+## Supported Operating Systems
+
+The deployment scripts are designed for **RHEL 9–based Linux distributions**.
+
+The following environments are currently supported and tested:
+
+- **RHEL 9**
+- **Rocky Linux 9.7**
+- **Amazon Linux 2023**
+- **Ubuntu 22.04**
+
+Other **RHEL 9 compatible distributions** (such as AlmaLinux 9) may also work but have not been explicitly tested.
+
+> ⚠️ RHEL/Rocky **10 and newer releases are not currently supported**.
+
+The installation automatically detects the container engine and will use:
+
+- **Podman** on RHEL-based systems
+- **Docker** on Ubuntu systems
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ The deployment supports both the default IriusRisk container registry and custom
 
 During installation you will be prompted to select the image source:
 
-1) Default IriusRisk registry  
+1) Default IriusRisk registry
 2) Custom registry
 
 ### Default Registry
@@ -365,9 +365,9 @@ docker.io/continuumsecurity/iriusrisk-prod
 
 Example images:
 
-docker.io/continuumsecurity/iriusrisk-prod:nginx  
-docker.io/continuumsecurity/iriusrisk-prod:tomcat-4  
-docker.io/continuumsecurity/iriusrisk-prod:startleft  
+docker.io/continuumsecurity/iriusrisk-prod:nginx
+docker.io/continuumsecurity/iriusrisk-prod:tomcat-4
+docker.io/continuumsecurity/iriusrisk-prod:startleft
 docker.io/continuumsecurity/iriusrisk-prod:reporting-module
 
 ### Custom Registry
@@ -389,9 +389,9 @@ myorg/iriusrisk-prod
 
 Images will then be resolved as:
 
-docker.io/myorg/iriusrisk-prod:nginx  
-docker.io/myorg/iriusrisk-prod:tomcat-4  
-docker.io/myorg/iriusrisk-prod:startleft  
+docker.io/myorg/iriusrisk-prod:nginx
+docker.io/myorg/iriusrisk-prod:tomcat-4
+docker.io/myorg/iriusrisk-prod:startleft
 docker.io/myorg/iriusrisk-prod:reporting-module
 
 This allows organizations to mirror or host IriusRisk images in their own container registry.
@@ -407,12 +407,12 @@ If your environment restricts outbound internet traffic, the following destinati
 
 Required to download the deployment templates.
 
-https://github.com  
+https://github.com
 https://raw.githubusercontent.com
 
 Example usage:
 
-curl https://raw.githubusercontent.com/iriusrisk/onprem-templates/...  
+curl https://raw.githubusercontent.com/iriusrisk/onprem-templates/...
 git clone https://github.com/iriusrisk/onprem-templates.git
 
 ---
@@ -423,15 +423,15 @@ Required to download IriusRisk container images.
 
 Default registry:
 
-docker.io  
-registry-1.docker.io  
+docker.io
+registry-1.docker.io
 auth.docker.io
 
 Example images:
 
-docker.io/continuumsecurity/iriusrisk-prod:nginx  
-docker.io/continuumsecurity/iriusrisk-prod:tomcat-*  
-docker.io/continuumsecurity/iriusrisk-prod:startleft  
+docker.io/continuumsecurity/iriusrisk-prod:nginx
+docker.io/continuumsecurity/iriusrisk-prod:tomcat-*
+docker.io/continuumsecurity/iriusrisk-prod:startleft
 docker.io/continuumsecurity/iriusrisk-prod:reporting-module
 
 If a custom registry is used, access must be allowed to that registry instead.
@@ -444,27 +444,54 @@ The installer automatically installs required packages depending on the distribu
 
 Typical repositories include:
 
-Ubuntu / Debian
+**Ubuntu / Debian**
 
-archive.ubuntu.com  
+archive.ubuntu.com
 security.ubuntu.com
 
-RHEL / Rocky / AlmaLinux
+**RHEL / Rocky / AlmaLinux**
 
-dl.fedoraproject.org  
+dl.fedoraproject.org
 mirrorlist.centos.org
 
-Amazon Linux
+**Amazon Linux**
 
 amazonlinux.*.amazonaws.com
+
+For Podman-based installations on RHEL-compatible systems, the installer also downloads the EPEL release package from:
+
+https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
 ---
 
 ### PostgreSQL Image
 
-If internal PostgreSQL is used, the following image is downloaded:
+If internal PostgreSQL is used, the default base image is:
 
 docker.io/library/postgres:15.4
+
+If a custom PostgreSQL image is selected during setup, access must be allowed to that image registry as well.
+
+---
+
+### Additional Package Sources Used During Podman Image Customization
+
+For Podman deployments, the script customizes local `nginx` and `tomcat` images in `build_podman_custom_images()`.
+
+During that step, additional packages may be installed **inside the container image** depending on the base image being used. This can require outbound access to upstream package repositories such as:
+
+**Alpine-based images**
+
+https://dl-cdn.alpinelinux.org
+http://nginx.org
+
+**Debian / Ubuntu-based images**
+
+http://deb.debian.org
+http://security.debian.org
+http://apt.postgresql.org
+
+The exact repositories contacted depend on the base image contents and package manager used by the source image.
 
 ---
 
@@ -476,33 +503,57 @@ If you configure external PostgreSQL or custom container registries, network acc
 
 ### Fully Air-Gapped Environments
 
-If outbound internet access is not allowed, deployment can still be performed by:
+If outbound internet access is not allowed, deployment can still be performed using offline mode. 
+To use offline mode, request the offline bundle from the support team and copy it to the target host.
 
-- Mirroring container images in an internal registry
-- Cloning this repository internally
-- Using internal OS package mirrors
+### Install using offline bundle
+
+Assuming the bundle file is named `iriusrisk-offline-bundle-4-install.tar.gz` and will be copied to the user home directory:
+
+```bash
+scp iriusrisk-offline-bundle-4-install.tar.gz user@your-instance:/home/user/
+ssh user@your-instance
+
+tar -xf iriusrisk-offline-bundle-4-install.tar.gz
+cd ~/irius-offline-bundle/onprem-templates/scripts
+
+./one-click.sh --offline --bundle "$HOME/irius-offline-bundle"
+
+```
+
+### Upgrade using offline bundle
+
+```bash
+
+scp iriusrisk-offline-bundle-4-install.tar.gz user@your-instance:/home/user/
+ssh user@your-instance
+
+tar -xf iriusrisk-offline-bundle-4-install.tar.gz
+cd ~/irius-offline-bundle/onprem-templates/scripts
+
+./upgrade.sh --offline --bundle "$HOME/irius-offline-bundle"
+
+```
 
 ---
 
 ## Supported Operating Systems
 
-The deployment scripts are designed for **RHEL 9–based Linux distributions**.
-
-The following environments are currently supported and tested:
+The deployment scripts have been tested on the following Linux distributions:
 
 - **RHEL 9**
 - **Rocky Linux 9.7**
 - **Amazon Linux 2023**
 - **Ubuntu 22.04**
 
-Other **RHEL 9 compatible distributions** (such as AlmaLinux 9) may also work but have not been explicitly tested.
+Other RHEL 9 compatible distributions (such as AlmaLinux 9) may also work but have not been explicitly tested.
 
 > ⚠️ RHEL/Rocky **10 and newer releases are not currently supported**.
 
 The installation automatically detects the container engine and will use:
 
 - **Podman** on RHEL-based systems
-- **Docker** on Ubuntu systems
+- **Docker** on Ubuntu and Amazon Linux systems
 
 ---
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    image: docker.io/continuumsecurity/iriusrisk-prod:nginx
+    image: ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:nginx
     container_name: iriusrisk-nginx
     networks:
       - iriusrisk-frontend
@@ -28,7 +28,7 @@ services:
       - grails_env=production
       - STARTLEFT_URL=http://startleft:8081/api/v1/startleft/iac
       - IRIUS_JWT_PRIVATE_KEY_PATH=/etc/irius/ec_private.pem
-      - IRIUS_REPORTING_MODULE_URL=http://reporting-module:3000      
+      - IRIUS_REPORTING_MODULE_URL=http://reporting-module:3000
       - CATALINA_OPTS=
             -XX:+UseParallelGC
             -XX:+UseContainerSupport
@@ -36,7 +36,7 @@ services:
             -XX:MaxMetaspaceSize=2G
             -XX:ReservedCodeCacheSize=2G
             -XX:MaxRAMPercentage=50
-    image: docker.io/continuumsecurity/iriusrisk-prod:tomcat-4
+    image: ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:tomcat-4
     container_name: iriusrisk-tomcat
     networks:
       - iriusrisk-frontend
@@ -49,7 +49,7 @@ services:
   startleft:
     environment:
       - IRIUS_SERVER=http://tomcat:80
-    image: docker.io/continuumsecurity/iriusrisk-prod:startleft
+    image: ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:startleft
     container_name: iriusrisk-startleft
     command: ["uvicorn", "startleft.startleft.api.fastapi_server:webapp", "--host", "0.0.0.0", "--port", "8081"]
     networks:
@@ -60,7 +60,7 @@ services:
     cpu_shares: 128
 
   reporting-module:
-    image: docker.io/continuumsecurity/iriusrisk-prod:reporting-module
+    image: ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:reporting-module
     container_name: reporting-module
     networks:
       - iriusrisk-backend

--- a/podman/podman-compose.yml
+++ b/podman/podman-compose.yml
@@ -49,7 +49,7 @@ services:
   startleft:
     environment:
       - IRIUS_SERVER=http://tomcat:8080
-    image: docker.io/continuumsecurity/iriusrisk-prod:startleft
+    image: ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:startleft
     container_name: iriusrisk-startleft
     command: ["uvicorn", "startleft.startleft.api.fastapi_server:webapp", "--host", "0.0.0.0", "--port", "8081"]
     networks:
@@ -58,7 +58,7 @@ services:
     mem_limit: 2G
 
   reporting-module:
-    image: docker.io/continuumsecurity/iriusrisk-prod:reporting-module
+    image: ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:reporting-module
     container_name: reporting-module
     networks:
       - iriusrisk-backend

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -80,6 +80,13 @@ function image_ref() {
 }
 
 function prompt_registry_settings() {
+	if [ "${OFFLINE:-0}" -eq 1 ]; then
+		echo "Offline mode detected."
+		echo "Select option 1 if you are using the bundle images as provided (default tags)."
+		echo "Select option 2 only if you need to retag images to a custom registry/namespace."
+		echo
+	fi
+
 	echo "Container image source:"
 	echo "  1) Default IriusRisk registry"
 	echo "  2) Custom registry"
@@ -628,7 +635,7 @@ function container_registry_login() {
 		return 0
 	fi
 
-	prompt_registry_password
+	[[ -z ${REGISTRY_PASS:-} ]] && prompt_registry_password
 
 	if [[ $CONTAINER_ENGINE == "docker" ]]; then
 		echo "$REGISTRY_PASS" | docker login "$registry_url" -u "$registry_user" --password-stdin
@@ -1714,8 +1721,79 @@ function offline_load_images() {
 		fi
 	done
 
+	# Retag bundle-loaded images to the registry/namespace selected for this deployment.
+	retag_offline_component_from_bundle_if_needed \
+		"$img_dir" \
+		"nginx-rhel" \
+		"$(image_ref "nginx")"
+
+	retag_offline_component_from_bundle_if_needed \
+		"$img_dir" \
+		"tomcat-rhel" \
+		"$(image_ref "tomcat-$(tr -d '[:space:]' <"${OFFLINE_BUNDLE_DIR}/iriusrisk_version")")"
+
+	retag_offline_component_from_bundle_if_needed \
+		"$img_dir" \
+		"startleft" \
+		"$(image_ref "startleft")"
+
+	retag_offline_component_from_bundle_if_needed \
+		"$img_dir" \
+		"reporting-module" \
+		"$(image_ref "reporting-module")"
+
 	echo "[offline] Done. Current images:"
 	podman images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Created}}\t{{.Size}}"
+}
+
+function retag_offline_component_from_bundle_if_needed() {
+	local img_dir="$1"
+	local component="$2"
+	local target_ref="$3"
+
+	local tarball=""
+	local base=""
+	local source_ref=""
+
+	tarball="$(find "$img_dir" -maxdepth 1 -type f -name "*${component}.oci.tar" | head -n1)"
+	[[ -z $tarball ]] && {
+		echo "[offline] WARNING: no archive found for component '$component'"
+		return 0
+	}
+
+	base="$(basename "$tarball" .oci.tar)"
+
+	if [[ $base == localhost_* ]]; then
+		if [[ $base == localhost_nginx-rhel ]]; then
+			source_ref="localhost/nginx-rhel:latest"
+		elif [[ $base == localhost_tomcat-rhel ]]; then
+			source_ref="localhost/tomcat-rhel:latest"
+		elif [[ $base == localhost_postgres-gpg_15.4 ]]; then
+			source_ref="localhost/postgres-gpg:15.4"
+		else
+			echo "[offline] WARNING: unsupported localhost archive name: $(basename "$tarball")"
+			return 0
+		fi
+	else
+		source_ref="$(_ref_from_filename "$base")"
+	fi
+
+	if [[ -z $source_ref ]]; then
+		echo "[offline] WARNING: could not derive source ref for '$component' from $(basename "$tarball")"
+		return 0
+	fi
+
+	if [[ $source_ref == "$target_ref" ]]; then
+		echo "[offline] No retag needed for $component ($source_ref)"
+		return 0
+	fi
+
+	if podman image exists "$source_ref"; then
+		echo "[offline] Retagging $source_ref -> $target_ref"
+		podman tag "$source_ref" "$target_ref"
+	else
+		echo "[offline] WARNING: source image not found after load: $source_ref"
+	fi
 }
 
 function ensure_subids_for_user() {

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -69,9 +69,81 @@ function prompt_postgres_option() {
 	POSTGRES_SETUP_OPTION="$pg_option"
 }
 
+: "${REGISTRY_URL:=docker.io}"
+: "${REGISTRY_NAMESPACE:=continuumsecurity/iriusrisk-prod}"
+: "${REGISTRY_USERNAME:=iriusrisk}"
+: "${POSTGRES_BASE_IMAGE:=docker.io/library/postgres:15.4}"
+
+function image_ref() {
+	local tag="$1"
+	echo "${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:${tag}"
+}
+
+function prompt_registry_settings() {
+	echo "Container image source:"
+	echo "  1) Default IriusRisk registry"
+	echo "  2) Custom registry"
+
+	while true; do
+		read -rp "Enter 1 or 2: " registry_option
+		case "$registry_option" in
+			1)
+				REGISTRY_URL="docker.io"
+				REGISTRY_NAMESPACE="continuumsecurity/iriusrisk-prod"
+				REGISTRY_USERNAME="iriusrisk"
+				break
+				;;
+			2)
+				REGISTRY_URL=$(prompt_nonempty "Enter registry URL")
+				REGISTRY_NAMESPACE=$(prompt_nonempty "Enter image repository path (e.g. myteam/iriusrisk-prod)")
+				REGISTRY_USERNAME=$(prompt_nonempty "Enter registry username")
+				break
+				;;
+			*)
+				echo "Invalid input: '$registry_option'. Please enter 1 or 2."
+				;;
+		esac
+	done
+
+	export REGISTRY_URL REGISTRY_NAMESPACE REGISTRY_USERNAME
+}
+
 function prompt_registry_password() {
-	read -srp "Enter the container registry password for user 'iriusrisk': " REGISTRY_PASS
+	local registry_user="${REGISTRY_USERNAME:-iriusrisk}"
+	read -srp "Enter the container registry password for user '${registry_user}': " REGISTRY_PASS
 	echo
+}
+
+function prompt_postgres_image_source() {
+	if [[ ${REGISTRY_URL:-docker.io} == "docker.io" && ${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod} == "continuumsecurity/iriusrisk-prod" ]]; then
+		POSTGRES_BASE_IMAGE="docker.io/library/postgres:15.4"
+		export POSTGRES_BASE_IMAGE
+		echo "Using default PostgreSQL base image: $POSTGRES_BASE_IMAGE"
+		return 0
+	fi
+
+	echo "PostgreSQL base image source:"
+	echo "  1) Default public image (docker.io/library/postgres:15.4)"
+	echo "  2) Custom image"
+
+	while true; do
+		read -rp "Enter 1 or 2: " pg_img_option
+		case "$pg_img_option" in
+			1)
+				POSTGRES_BASE_IMAGE="docker.io/library/postgres:15.4"
+				break
+				;;
+			2)
+				POSTGRES_BASE_IMAGE=$(prompt_nonempty "Enter PostgreSQL base image reference")
+				break
+				;;
+			*)
+				echo "Invalid input: '$pg_img_option'. Please enter 1 or 2."
+				;;
+		esac
+	done
+
+	export POSTGRES_BASE_IMAGE
 }
 
 function prompt_for_docker_user() {
@@ -153,6 +225,12 @@ function install_docker() {
 	fi
 }
 
+function ensure_podman_network_kernel_modules() {
+	echo "Ensuring required Podman networking kernel modules are loaded..."
+	sudo modprobe ip_tables || true
+	sudo modprobe iptable_nat || true
+}
+
 function install_podman() {
 	echo "Installing Podman and podman-compose..."
 	sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm || true
@@ -160,6 +238,9 @@ function install_podman() {
 		sudo dnf install -y podman python3-pip
 		python3 -m pip install --upgrade --user podman-compose python-dotenv
 	}
+
+	# Ensure required networking kernel modules are loaded
+	ensure_podman_network_kernel_modules
 }
 
 function install_git() {
@@ -256,10 +337,17 @@ function install_and_configure_postgres() {
 		sg docker -c "$compose_tool -f $(basename "$postgres_file") up -d postgres"
 	elif [[ $CONTAINER_ENGINE == "podman" ]]; then
 		local compose_tool="podman-compose"
-		# Build/refresh a tiny postgres image that decrypts at runtime (no plaintext on disk)
-		local base_image="docker.io/library/postgres:15.4"
 		local patched_image="localhost/postgres-gpg:15.4"
 		local tmp_name="temp-postgres"
+		local base_image
+
+		if [[ $OFFLINE -eq 0 ]]; then
+			prompt_postgres_image_source
+		fi
+		base_image="${POSTGRES_BASE_IMAGE:-docker.io/library/postgres:15.4}"
+
+		# Ensure required networking kernel modules are loaded before any podman networking work
+		ensure_podman_network_kernel_modules
 
 		# Create and encrypt db pass secret
 		encrypt_and_store_secret "$DB_PASS" "db_pwd" "db_privkey"
@@ -314,6 +402,9 @@ EOF
 		if [[ -n $ids ]]; then podman rm -f $ids || true; fi
 
 		sudo rm -rf ./postgres/data
+
+		# Ensure required networking kernel modules are loaded again before compose up
+		ensure_podman_network_kernel_modules
 
 		# Bring up just Postgres (with secrets override)
 		eval "$compose_tool -f $(basename "$postgres_file") up -d postgres"
@@ -492,10 +583,11 @@ function create_certificates() {
 	echo "📄 Certificates present in $CERT_DIR"
 }
 
-function is_logged_in_as_iriusrisk() {
+function is_logged_in_to_registry_user() {
+	local expected_user="${REGISTRY_USERNAME:-iriusrisk}"
+	local auth_key_primary="${REGISTRY_URL:-docker.io}"
+	local auth_key_dockerhub_alt="https://index.docker.io/v1/"
 	local config_candidates=()
-	local auth_key_dockerhub1="docker.io"
-	local auth_key_dockerhub2="https://index.docker.io/v1/"
 	local auth_base64=""
 	local auth_user=""
 
@@ -515,35 +607,36 @@ function is_logged_in_as_iriusrisk() {
 	for cfg in "${config_candidates[@]}"; do
 		[[ -f $cfg ]] || continue
 		if [[ $cfg == "/run/containers/0/auth.json" ]]; then
-			auth_base64=$(sudo jq -r ".auths[\"$auth_key_dockerhub1\"].auth // .auths[\"$auth_key_dockerhub2\"].auth // empty" "$cfg" 2>/dev/null)
+			auth_base64=$(sudo jq -r ".auths[\"$auth_key_primary\"].auth // .auths[\"$auth_key_dockerhub_alt\"].auth // empty" "$cfg" 2>/dev/null)
 		else
-			auth_base64=$(jq -r ".auths[\"$auth_key_dockerhub1\"].auth // .auths[\"$auth_key_dockerhub2\"].auth // empty" "$cfg" 2>/dev/null)
+			auth_base64=$(jq -r ".auths[\"$auth_key_primary\"].auth // .auths[\"$auth_key_dockerhub_alt\"].auth // empty" "$cfg" 2>/dev/null)
 		fi
 		[[ -n $auth_base64 ]] && break
 	done
 
 	[[ -z $auth_base64 ]] && return 1
 	auth_user=$(echo "$auth_base64" | base64 -d 2>/dev/null | cut -d: -f1)
-	[[ $auth_user == "iriusrisk" ]]
+	[[ $auth_user == "$expected_user" ]]
 }
 
 function container_registry_login() {
-	local registry_url="${1:-}"
+	local registry_url="${REGISTRY_URL:-docker.io}"
+	local registry_user="${REGISTRY_USERNAME:-iriusrisk}"
 
-	if is_logged_in_as_iriusrisk $CONTAINER_ENGINE; then
-		echo "Already logged in to Docker Hub as 'iriusrisk', skipping login prompt."
+	if is_logged_in_to_registry_user; then
+		echo "Already logged in to registry '$registry_url' as '$registry_user', skipping login prompt."
 		return 0
 	fi
 
 	prompt_registry_password
 
 	if [[ $CONTAINER_ENGINE == "docker" ]]; then
-		echo "$REGISTRY_PASS" | docker login -u iriusrisk --password-stdin
+		echo "$REGISTRY_PASS" | docker login "$registry_url" -u "$registry_user" --password-stdin
 	elif [[ $CONTAINER_ENGINE == "podman" ]]; then
 		if [[ "$(id -u)" -eq 0 ]]; then
-			echo "$REGISTRY_PASS" | sudo podman login -u iriusrisk docker.io --password-stdin
+			echo "$REGISTRY_PASS" | sudo podman login "$registry_url" -u "$registry_user" --password-stdin
 		else
-			echo "$REGISTRY_PASS" | podman login -u iriusrisk docker.io --password-stdin
+			echo "$REGISTRY_PASS" | podman login "$registry_url" -u "$registry_user" --password-stdin
 		fi
 	else
 		echo "Unknown container engine: $CONTAINER_ENGINE" >&2
@@ -627,17 +720,22 @@ function build_podman_custom_images() {
 	# Clean any temp containers
 	podman rm -f temp-nginx temp-tomcat 2>/dev/null || true
 
+	local nginx_image
+	local tomcat_image
+	nginx_image="$(image_ref "nginx")"
+	tomcat_image="$(image_ref "tomcat-${tv}")"
+
 	if [ "$OFFLINE" -eq 0 ]; then
 		echo "Pulling base images..."
-		podman pull docker.io/continuumsecurity/iriusrisk-prod:nginx >/dev/null
-		podman pull "docker.io/continuumsecurity/iriusrisk-prod:tomcat-${tv}" >/dev/null || {
-			echo "ERROR: Unable to pull docker.io/continuumsecurity/iriusrisk-prod:tomcat-${tv}" >&2
+		podman pull "$nginx_image" >/dev/null
+		podman pull "$tomcat_image" >/dev/null || {
+			echo "ERROR: Unable to pull $tomcat_image" >&2
 			return 1
 		}
 	fi
 
 	echo "Customizing nginx → localhost/nginx-rhel"
-	podman run --name temp-nginx --user root --entrypoint /bin/sh docker.io/continuumsecurity/iriusrisk-prod:nginx \
+	podman run --name temp-nginx --user root --entrypoint /bin/sh "$nginx_image" \
 		-c "set -eu; \
         if [ -f /etc/alpine-release ]; then apk add --no-cache libcap; else \
             (apt-get update && apt-get install -y --no-install-recommends libcap2-bin) || true; fi; \
@@ -655,7 +753,7 @@ function build_podman_custom_images() {
 		--name temp-tomcat \
 		--user root \
 		--entrypoint /bin/sh \
-		"docker.io/continuumsecurity/iriusrisk-prod:tomcat-${tv}" \
+		"$tomcat_image" \
 		-c '\
       set -eu; \
       if [ -f /etc/alpine-release ]; then \
@@ -968,20 +1066,21 @@ EOF
 # Usage: update_component_tag startleft "$SL_VER"
 function update_component_tag() {
 	local comp="$1" ver="$2"
+	local registry_url_escaped registry_ns_escaped
+
 	[[ -z $ver ]] && {
 		echo "NOTE: No version provided for $comp in JSON; skipping."
 		return 0
 	}
 
-	# Match:
-	#   image: docker.io/continuumsecurity/iriusrisk-prod:<comp>
-	#   image: docker.io/continuumsecurity/iriusrisk-prod:<comp>-<digits[.digits...]>
-	# (docker.io/ prefix optional; whitespace & comments preserved)
-	if grep -qE "^[[:space:]]*image:[[:space:]]*(docker\.io/)?continuumsecurity/iriusrisk-prod:${comp}(-[0-9.]+)?([[:space:]]|$)" "$COMPOSE_YML"; then
+	registry_url_escaped=$(printf '%s' "${REGISTRY_URL:-docker.io}" | sed 's/[.[\*^$()+?{|]/\\&/g')
+	registry_ns_escaped=$(printf '%s' "${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}" | sed 's/[.[\*^$()+?{|]/\\&/g')
+
+	if grep -qE "^[[:space:]]*image:[[:space:]]*(${registry_url_escaped}/)?${registry_ns_escaped}:${comp}(-[0-9.]+)?([[:space:]]|$)" "$COMPOSE_YML"; then
 		sed -i -E \
-			"s@(^[[:space:]]*image:[[:space:]]*(docker\.io/)?continuumsecurity/iriusrisk-prod:${comp})(-[0-9.]+)?([[:space:]]*(#.*)?\$)@\\1-${ver}\\4@" \
+			"s@(^[[:space:]]*image:[[:space:]]*(${registry_url_escaped}/)?${registry_ns_escaped}:${comp})(-[0-9.]+)?([[:space:]]*(#.*)?\$)@\\1-${ver}\\4@" \
 			"$COMPOSE_YML"
-		echo "Updated ${comp} image tag → docker.io/continuumsecurity/iriusrisk-prod:${comp}-${ver}"
+		echo "Updated ${comp} image tag → ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:${comp}-${ver}"
 	else
 		echo "WARNING: No '${comp}' image line found in $COMPOSE_YML; skipping ${comp} update."
 	fi
@@ -1036,6 +1135,11 @@ function detect_engine_ctx() {
 	SERVICE_NAME="iriusrisk-$CONTAINER_ENGINE.service"
 	NEED_DOCKER_CFG=""
 
+	local extra_registry_env=""
+	if [[ ${REGISTRY_URL:-docker.io} != "docker.io" || ${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod} != "continuumsecurity/iriusrisk-prod" ]]; then
+		extra_registry_env=$'\nEnvironment=REGISTRY_URL='"${REGISTRY_URL}"$'\nEnvironment=REGISTRY_NAMESPACE='"${REGISTRY_NAMESPACE}"
+	fi
+
 	case "$ENGINE" in
 		docker)
 			COMPOSE_INVOKE="docker-compose"
@@ -1045,7 +1149,7 @@ function detect_engine_ctx() {
 			SYSTEMCTL="sudo systemctl"
 			UNIT_AFTER=$'After=network.target docker.service'
 			UNIT_REQUIRES=$'Requires=docker.service'
-			UNIT_ENV_LINES=$'Environment=DOCKER_CONFIG=/etc/docker\nEnvironment=COMPOSE_INTERACTIVE_NO_CLI=1'
+			UNIT_ENV_LINES=$'Environment=DOCKER_CONFIG=/etc/docker\nEnvironment=COMPOSE_INTERACTIVE_NO_CLI=1'"${extra_registry_env}"
 			NEED_DOCKER_CFG="true"
 			;;
 		podman)
@@ -1056,7 +1160,7 @@ function detect_engine_ctx() {
 			SYSTEMCTL="systemctl --user"
 			UNIT_AFTER=$'After=network-online.target\nWants=network-online.target'
 			UNIT_REQUIRES=""
-			UNIT_ENV_LINES=$'Environment=PODMAN_SYSTEMD_UNIT=%n'
+			UNIT_ENV_LINES=$'Environment=PODMAN_SYSTEMD_UNIT=%n'"${extra_registry_env}"
 			;;
 		*)
 			echo "Unknown engine '$ENGINE'." >&2
@@ -1099,6 +1203,9 @@ function deploy_stack() {
 	fi
 
 	if [[ $ENGINE == "podman" && $OFFLINE -eq 0 ]]; then
+		# Ensure required networking kernel modules are loaded before podman compose/network work
+		ensure_podman_network_kernel_modules
+
 		# Build custom images for Podman
 		build_podman_custom_images
 	fi

--- a/scripts/one-click.sh
+++ b/scripts/one-click.sh
@@ -139,6 +139,10 @@ else
 	exit 1
 fi
 
+if [ "$OFFLINE" -eq 0 ]; then
+	prompt_registry_settings
+fi
+
 prompt_postgres_option setup
 
 if [[ $POSTGRES_SETUP_OPTION == "1" ]]; then

--- a/scripts/one-click.sh
+++ b/scripts/one-click.sh
@@ -35,6 +35,8 @@ set -- "${ARGS[@]:-}"
 
 export OFFLINE OFFLINE_BUNDLE_DIR
 
+prompt_registry_settings
+
 # —————————————————————————————————————————————————————————————
 # Script Start
 # —————————————————————————————————————————————————————————————
@@ -137,10 +139,6 @@ elif [[ $CONTAINER_ENGINE == "podman" ]]; then
 else
 	echo "Unknown container engine: $CONTAINER_ENGINE"
 	exit 1
-fi
-
-if [ "$OFFLINE" -eq 0 ]; then
-	prompt_registry_settings
 fi
 
 prompt_postgres_option setup

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -86,89 +86,101 @@ printf '%s\n' "$PREV_VERSION" >/tmp/iriusrisk_previous_version.txt || true
 echo "Detected current IriusRisk version (pre-upgrade): $PREV_VERSION"
 
 # —————————————————————————————————————————————————————————————
-# 3. Discover highest tomcat tag (Hub API v2, private repo) & choose version
+# 3. Registry settings + discover highest tomcat tag when applicable
 # —————————————————————————————————————————————————————————————
 if [ "$OFFLINE" -eq 0 ]; then
-	REPO_NS="continuumsecurity"
-	REPO_NAME="iriusrisk-prod"
-	HUB_LOGIN_URL="https://hub.docker.com/v2/users/login/"
-	TAGS_URL_BASE="https://hub.docker.com/v2/repositories/${REPO_NS}/${REPO_NAME}/tags"
-	echo "Discovering tomcat tags on Docker Hub for ${REPO_NS}/${REPO_NAME} ..."
+	prompt_registry_settings
 
-	# Ensure we have a password; your helper already sets REGISTRY_PASS
-	[[ -z ${REGISTRY_PASS:-} ]] && prompt_registry_password
-
-	# Obtain Hub JWT (separate from docker login credential store)
-	HUB_TOKEN="$(
-		curl -fsSL -H 'Content-Type: application/json' \
-			-d "{\"username\":\"iriusrisk\",\"password\":\"${REGISTRY_PASS}\"}" \
-			"${HUB_LOGIN_URL}" 2>/dev/null | sed -n 's/.*"token":"\([^"]*\)".*/\1/p'
-	)" || true
-
-	if [[ -z $HUB_TOKEN || $HUB_TOKEN == "null" ]]; then
-		echo "WARNING: Hub login failed; you can still type the version manually."
-	fi
-
-	# Gather tomcat-* tags from Hub API (paginate via .next)
-	versions=()
-	if [[ -n $HUB_TOKEN ]]; then
-		url="${TAGS_URL_BASE}?page_size=100&name=tomcat"
-		while [[ -n $url ]]; do
-			page="$(curl -fsSL -H "Authorization: JWT ${HUB_TOKEN}" "$url" 2>/dev/null || true)"
-			[[ -z $page ]] && break
-
-			if command -v jq >/dev/null 2>&1; then
-				while IFS= read -r tag; do
-					[[ $tag =~ ^tomcat-([0-9]+(\.[0-9]+){0,2})$ ]] && versions+=("${tag#tomcat-}")
-				done < <(printf '%s' "$page" | jq -r '.results[].name' 2>/dev/null)
-				next="$(printf '%s' "$page" | jq -r '.next // empty')"
-			else
-				while IFS= read -r tag; do
-					tag="${tag#\"}"
-					tag="${tag%\"}"
-					[[ $tag =~ ^tomcat-([0-9]+(\.[0-9]+){0,2})$ ]] && versions+=("${tag#tomcat-}")
-				done < <(printf '%s' "$page" | grep -o '"name"[[:space:]]*:[[:space:]]*"tomcat-[^"]*"' | sed -E 's/.*"tomcat-/tomcat-/' | sed -E 's/"$//')
-				next="$(printf '%s' "$page" | grep -o '"next"[[:space:]]*:[[:space:]]*"[^"]*"' | sed -E 's/.*:"(.*)"/\1/')"
-				[[ $next == "null" ]] && next=""
-			fi
-
-			url="$next"
-		done
-	fi
-
-	# Choose default: prefer full semver X.Y.Z; else highest major
-	DEFAULT_VERSION=""
-	if [[ ${#versions[@]} -gt 0 ]]; then
-		full=() majors=()
-		for v in "${versions[@]}"; do
-			[[ $v =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && full+=("$v") || majors+=("$v")
-		done
-		if [[ ${#full[@]} -gt 0 ]]; then
-			mapfile -t sorted_full < <(printf '%s\n' "${full[@]}" | sort -uV)
-			DEFAULT_VERSION="${sorted_full[-1]}"
-		elif [[ ${#majors[@]} -gt 0 ]]; then
-			mapfile -t sorted_maj < <(printf '%s\n' "${majors[@]}" | sort -u)
-			DEFAULT_VERSION="${sorted_maj[-1]}"
-		fi
-	fi
-	[[ -z $DEFAULT_VERSION ]] && DEFAULT_VERSION="4"
-	echo "Highest available tomcat version (Hub): $DEFAULT_VERSION"
-
-	read -r -p "Version to upgrade to [${DEFAULT_VERSION}]: " CHOSEN_VERSION
-	[[ -z $CHOSEN_VERSION ]] && CHOSEN_VERSION="$DEFAULT_VERSION"
-	if [[ ! $CHOSEN_VERSION =~ ^[0-9]+$ && ! $CHOSEN_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-		echo "ERROR: Version must be 'N' or 'N.N.N' (e.g., 4 or 4.46.9). You entered: $CHOSEN_VERSION" >&2
-		exit 6
-	fi
-
-	TARGET_TAG="tomcat-$CHOSEN_VERSION"
 	COMPOSE_YML="$COMPOSE_DIR/$CONTAINER_ENGINE-compose.yml"
 	[[ -f $COMPOSE_YML ]] || {
 		echo "ERROR: Compose file not found: $COMPOSE_YML" >&2
 		exit 4
 	}
+
+	if [[ ${REGISTRY_URL:-docker.io} != "docker.io" ]]; then
+		echo "Custom registry selected: skipping Docker Hub tag discovery."
+		read -r -p "Version to upgrade to: " CHOSEN_VERSION
+		if [[ ! $CHOSEN_VERSION =~ ^[0-9]+$ && ! $CHOSEN_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+			echo "ERROR: Version must be 'N' or 'N.N.N' (e.g., 4 or 4.46.9). You entered: $CHOSEN_VERSION" >&2
+			exit 6
+		fi
+	else
+		REPO_NS="${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}"
+		HUB_LOGIN_URL="https://hub.docker.com/v2/users/login/"
+		TAGS_URL_BASE="https://hub.docker.com/v2/repositories/${REPO_NS}/tags"
+		echo "Discovering tomcat tags on Docker Hub for ${REPO_NS} ..."
+
+		# Ensure we have a password; helper will prompt if needed
+		[[ -z ${REGISTRY_PASS:-} ]] && prompt_registry_password
+
+		# Obtain Hub JWT (separate from docker login credential store)
+		HUB_TOKEN="$(
+			curl -fsSL -H 'Content-Type: application/json' \
+				-d "{\"username\":\"${REGISTRY_USERNAME:-iriusrisk}\",\"password\":\"${REGISTRY_PASS}\"}" \
+				"${HUB_LOGIN_URL}" 2>/dev/null | sed -n 's/.*"token":"\([^"]*\)".*/\1/p'
+		)" || true
+
+		if [[ -z $HUB_TOKEN || $HUB_TOKEN == "null" ]]; then
+			echo "WARNING: Hub login failed; you can still type the version manually."
+		fi
+
+		# Gather tomcat-* tags from Hub API (paginate via .next)
+		versions=()
+		if [[ -n $HUB_TOKEN ]]; then
+			url="${TAGS_URL_BASE}?page_size=100&name=tomcat"
+			while [[ -n $url ]]; do
+				page="$(curl -fsSL -H "Authorization: JWT ${HUB_TOKEN}" "$url" 2>/dev/null || true)"
+				[[ -z $page ]] && break
+
+				if command -v jq >/dev/null 2>&1; then
+					while IFS= read -r tag; do
+						[[ $tag =~ ^tomcat-([0-9]+(\.[0-9]+){0,2})$ ]] && versions+=("${tag#tomcat-}")
+					done < <(printf '%s' "$page" | jq -r '.results[].name' 2>/dev/null)
+					next="$(printf '%s' "$page" | jq -r '.next // empty')"
+				else
+					while IFS= read -r tag; do
+						tag="${tag#\"}"
+						tag="${tag%\"}"
+						[[ $tag =~ ^tomcat-([0-9]+(\.[0-9]+){0,2})$ ]] && versions+=("${tag#tomcat-}")
+					done < <(printf '%s' "$page" | grep -o '"name"[[:space:]]*:[[:space:]]*"tomcat-[^"]*"' | sed -E 's/.*"tomcat-/tomcat-/' | sed -E 's/"$//')
+					next="$(printf '%s' "$page" | grep -o '"next"[[:space:]]*:[[:space:]]*"[^"]*"' | sed -E 's/.*:"(.*)"/\1/')"
+					[[ $next == "null" ]] && next=""
+				fi
+
+				url="$next"
+			done
+		fi
+
+		# Choose default: prefer full semver X.Y.Z; else highest major
+		DEFAULT_VERSION=""
+		if [[ ${#versions[@]} -gt 0 ]]; then
+			full=() majors=()
+			for v in "${versions[@]}"; do
+				[[ $v =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && full+=("$v") || majors+=("$v")
+			done
+			if [[ ${#full[@]} -gt 0 ]]; then
+				mapfile -t sorted_full < <(printf '%s\n' "${full[@]}" | sort -uV)
+				DEFAULT_VERSION="${sorted_full[-1]}"
+			elif [[ ${#majors[@]} -gt 0 ]]; then
+				mapfile -t sorted_maj < <(printf '%s\n' "${majors[@]}" | sort -u)
+				DEFAULT_VERSION="${sorted_maj[-1]}"
+			fi
+		fi
+		[[ -z $DEFAULT_VERSION ]] && DEFAULT_VERSION="4"
+		echo "Highest available tomcat version (Hub): $DEFAULT_VERSION"
+
+		read -r -p "Version to upgrade to [${DEFAULT_VERSION}]: " CHOSEN_VERSION
+		[[ -z $CHOSEN_VERSION ]] && CHOSEN_VERSION="$DEFAULT_VERSION"
+		if [[ ! $CHOSEN_VERSION =~ ^[0-9]+$ && ! $CHOSEN_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+			echo "ERROR: Version must be 'N' or 'N.N.N' (e.g., 4 or 4.46.9). You entered: $CHOSEN_VERSION" >&2
+			exit 6
+		fi
+	fi
+
+	TARGET_TAG="tomcat-$CHOSEN_VERSION"
 else
 	CHOSEN_VERSION=$(tr -d '[:space:]' <"${OFFLINE_BUNDLE_DIR}/iriusrisk_version")
+	COMPOSE_YML="$COMPOSE_DIR/$CONTAINER_ENGINE-compose.yml"
 fi
 
 # —————————————————————————————————————————————————————————————
@@ -252,11 +264,11 @@ echo "Compose dir backed up: $C_TAR_SIZE -> $OUT_COMPOSE_TAR"
 # —————————————————————————————————————————————————————————————
 
 if [ "$OFFLINE" -eq 1 ]; then
-	copy_with_fullref docker.io/continuumsecurity/iriusrisk-prod:startleft \
-		docker.io_continuumsecurity_iriusrisk-prod_startleft.oci.tar
+	copy_with_fullref "$(image_ref "startleft")" \
+		startleft.oci.tar
 
-	copy_with_fullref docker.io/continuumsecurity/iriusrisk-prod:reporting-module \
-		docker.io_continuumsecurity_iriusrisk-prod_reporting-module.oci.tar
+	copy_with_fullref "$(image_ref "reporting-module")" \
+		reporting-module.oci.tar
 
 	# Ensure your local custom images exist
 	# nginx:
@@ -305,12 +317,14 @@ fi
 # 10. Update compose tomcat tag (docker) or note podman build
 # —————————————————————————————————————————————————————————————
 if [[ $CONTAINER_ENGINE == "docker" ]]; then
-	# Update ONLY Tomcat line (matches major-only or full semver; docker.io prefix optional)
-	if grep -qE '^[[:space:]]*image:[[:space:]]*(docker\.io/)?continuumsecurity/iriusrisk-prod:tomcat-[0-9.]+([[:space:]]|$)' "$COMPOSE_YML"; then
+	registry_url_escaped=$(printf '%s' "${REGISTRY_URL:-docker.io}" | sed 's/[.[\*^$()+?{|]/\\&/g')
+	registry_ns_escaped=$(printf '%s' "${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}" | sed 's/[.[\*^$()+?{|]/\\&/g')
+
+	if grep -qE "^[[:space:]]*image:[[:space:]]*(${registry_url_escaped}/)?${registry_ns_escaped}:tomcat-[0-9.]+([[:space:]]|$)" "$COMPOSE_YML"; then
 		sed -i -E \
-			"s@(^[[:space:]]*image:[[:space:]]*(docker\.io/)?continuumsecurity/iriusrisk-prod:tomcat-)[0-9]+([.][0-9]+){0,2}([[:space:]]*(#.*)?\$)@\\1${CHOSEN_VERSION}\\4@" \
+			"s@(^[[:space:]]*image:[[:space:]]*(${registry_url_escaped}/)?${registry_ns_escaped}:tomcat-)[0-9]+([.][0-9]+){0,2}([[:space:]]*(#.*)?\$)@\\1${CHOSEN_VERSION}\\4@" \
 			"$COMPOSE_YML"
-		echo "Updated tomcat image tag → docker.io/continuumsecurity/iriusrisk-prod:tomcat-${CHOSEN_VERSION}"
+		echo "Updated tomcat image tag → ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:tomcat-${CHOSEN_VERSION}"
 	else
 		echo "ERROR: No tomcat image line found in $COMPOSE_YML (expected ':tomcat-<major>' or ':tomcat-<X.Y.Z>')." >&2
 		exit 5
@@ -355,6 +369,10 @@ if [[ $CONTAINER_ENGINE == "docker" ]]; then
 	container_registry_login
 fi
 
+if [[ $CONTAINER_ENGINE == "podman" ]]; then
+	ensure_podman_network_kernel_modules
+fi
+
 $CONTAINER_ENGINE system prune -f
 cd "$COMPOSE_DIR"
 
@@ -369,6 +387,10 @@ else
 fi
 
 echo "Restarting stack to complete upgrade"
+
+if [[ $CONTAINER_ENGINE == "podman" ]]; then
+	ensure_podman_network_kernel_modules
+fi
 
 # Spin up IriusRisk stack
 $COMPOSE_TOOL $COMPOSE_OVERRIDE up -d

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -85,11 +85,12 @@ fi
 printf '%s\n' "$PREV_VERSION" >/tmp/iriusrisk_previous_version.txt || true
 echo "Detected current IriusRisk version (pre-upgrade): $PREV_VERSION"
 
+prompt_registry_settings
+
 # —————————————————————————————————————————————————————————————
 # 3. Registry settings + discover highest tomcat tag when applicable
 # —————————————————————————————————————————————————————————————
 if [ "$OFFLINE" -eq 0 ]; then
-	prompt_registry_settings
 
 	COMPOSE_YML="$COMPOSE_DIR/$CONTAINER_ENGINE-compose.yml"
 	[[ -f $COMPOSE_YML ]] || {
@@ -265,15 +266,14 @@ echo "Compose dir backed up: $C_TAR_SIZE -> $OUT_COMPOSE_TAR"
 
 if [ "$OFFLINE" -eq 1 ]; then
 	copy_with_fullref "$(image_ref "startleft")" \
-		startleft.oci.tar
+		"$(image_ref "startleft" | sed 's#/#_#g; s#:#_#g').oci.tar"
 
 	copy_with_fullref "$(image_ref "reporting-module")" \
-		reporting-module.oci.tar
+		"$(image_ref "reporting-module" | sed 's#/#_#g; s#:#_#g').oci.tar"
 
 	# Ensure your local custom images exist
-	# nginx:
 	podman image exists localhost/nginx-rhel:latest || die "Missing image: localhost/nginx-rhel:latest"
-	# tomcat: ensure we have :latest (retag if only versioned exists)
+
 	if ! podman image exists localhost/tomcat-rhel:latest; then
 		if podman image exists "localhost/tomcat-rhel:tomcat-$TOMCAT_V"; then
 			echo "Retagging localhost/tomcat-rhel:tomcat-$TOMCAT_V -> localhost/tomcat-rhel:latest"
@@ -282,10 +282,9 @@ if [ "$OFFLINE" -eq 1 ]; then
 			die "Missing image: localhost/tomcat-rhel:(latest or tomcat-$TOMCAT_V)"
 		fi
 	fi
-	# postgres:
+
 	podman image exists localhost/postgres-gpg:15.4 || die "Missing image: localhost/postgres-gpg:15.4"
 
-	# Save local custom images with embedded refs
 	save_local_with_fullref localhost/nginx-rhel:latest localhost_nginx-rhel.oci.tar
 	save_local_with_fullref localhost/tomcat-rhel:latest localhost_tomcat-rhel.oci.tar
 	save_local_with_fullref localhost/postgres-gpg:15.4 localhost_postgres-gpg_15.4.oci.tar
@@ -317,16 +316,13 @@ fi
 # 10. Update compose tomcat tag (docker) or note podman build
 # —————————————————————————————————————————————————————————————
 if [[ $CONTAINER_ENGINE == "docker" ]]; then
-	registry_url_escaped=$(printf '%s' "${REGISTRY_URL:-docker.io}" | sed 's/[.[\*^$()+?{|]/\\&/g')
-	registry_ns_escaped=$(printf '%s' "${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}" | sed 's/[.[\*^$()+?{|]/\\&/g')
-
-	if grep -qE "^[[:space:]]*image:[[:space:]]*(${registry_url_escaped}/)?${registry_ns_escaped}:tomcat-[0-9.]+([[:space:]]|$)" "$COMPOSE_YML"; then
+	if grep -qE '^[[:space:]]*image:[[:space:]]*\$\{REGISTRY_URL:-docker\.io\}/\$\{REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod\}:tomcat-[0-9.]+' "$COMPOSE_YML"; then
 		sed -i -E \
-			"s@(^[[:space:]]*image:[[:space:]]*(${registry_url_escaped}/)?${registry_ns_escaped}:tomcat-)[0-9]+([.][0-9]+){0,2}([[:space:]]*(#.*)?\$)@\\1${CHOSEN_VERSION}\\4@" \
+			"s@(^[[:space:]]*image:[[:space:]]*\\\$\{REGISTRY_URL:-docker\.io\}/\\\$\{REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod\}:tomcat-)[0-9]+([.][0-9]+){0,2}([[:space:]]*(#.*)?\$)@\\1${CHOSEN_VERSION}\\4@" \
 			"$COMPOSE_YML"
-		echo "Updated tomcat image tag → ${REGISTRY_URL:-docker.io}/${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:tomcat-${CHOSEN_VERSION}"
+		echo "Updated tomcat image tag → \${REGISTRY_URL:-docker.io}/\${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod}:tomcat-${CHOSEN_VERSION}"
 	else
-		echo "ERROR: No tomcat image line found in $COMPOSE_YML (expected ':tomcat-<major>' or ':tomcat-<X.Y.Z>')." >&2
+		echo "ERROR: No tomcat image line found in $COMPOSE_YML (expected variable-based ':tomcat-<major>' or ':tomcat-<X.Y.Z>')." >&2
 		exit 5
 	fi
 else


### PR DESCRIPTION
Changes

This PR improves the on-prem deployment scripts by adding support for custom container registries across both online and offline installations, along with Podman reliability improvements.
Users can now choose between the default IriusRisk registry or a custom registry (URL + namespace), and this configuration is consistently applied during installation and upgrades.
Offline deployments now support both default bundle tags and custom registry setups via automatic image retagging.
Additionally, users can now provide their own PostgreSQL image when using a custom registry.

Additional improvements:

Fixed duplicate registry prompts
Ensured required Podman networking kernel modules are loaded
Updated README with offline usage guidance

Testing

Validated across multiple environments:
Rocky 9.7 / Podman — online + upgrade (default registry)
Rocky 9.7 / Podman — offline + upgrade (custom registry)
RHEL 9 / Podman — online + upgrade (custom registry)
Ubuntu 22.04 / Docker — online + upgrade (custom registry)
Ubuntu 22.04 / Docker — offline + upgrade (default registry)