### PR TITLE
DP1410: add logic to handle networking behind a proxy, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,130 @@ If you configure external PostgreSQL or custom container registries, network acc
 
 ---
 
+
+## 🌐 Proxy Configuration (Optional)
+
+If your environment requires outbound traffic to go through an HTTP/HTTPS proxy, the deployment scripts support proxy configuration via standard environment variables.
+
+This applies to:
+
+- Downloading dependencies (packages, images)
+- Podman image customization steps
+- Container runtime behavior
+- Systemd-managed services (Docker and Podman)
+
+---
+
+### 🔧 How to Configure a Proxy
+
+Before running the installer (`bootstrap.sh`, `one-click.sh`, or `upgrade.sh`), export the required proxy environment variables in your shell.
+
+Example:
+
+```bash
+export HTTP_PROXY=http://proxy.example.com:3128
+export HTTPS_PROXY=http://proxy.example.com:3128
+export NO_PROXY=localhost,127.0.0.1
+```
+
+Lowercase variants are also supported:
+
+```bash
+export http_proxy=http://proxy.example.com:3128
+export https_proxy=http://proxy.example.com:3128
+export no_proxy=localhost,127.0.0.1
+```
+
+Additional optional variables:
+
+```bash
+export FTP_PROXY=http://proxy.example.com:3128
+export ALL_PROXY=http://proxy.example.com:3128
+```
+
+---
+
+### ▶️ Running the Installer with Proxy
+
+Once the variables are set, run the installer as normal:
+
+```bash
+./bootstrap.sh
+```
+
+or:
+
+```bash
+./one-click.sh
+```
+
+No additional flags or configuration are required.
+
+---
+
+### ⚙️ What the Scripts Do Automatically
+
+If proxy variables are detected, the automation will:
+
+- Pass proxy settings into Podman build containers during image customization
+- Inject proxy variables into systemd service definitions
+- Ensure all runtime containers inherit the proxy configuration
+
+If no proxy variables are set, the scripts behave exactly as normal with no changes to the deployment flow.
+
+---
+
+### 🔍 Verifying Proxy Configuration
+
+Podman (rootless):
+
+```bash
+systemctl --user show-environment | grep -i proxy
+```
+
+Docker:
+
+```bash
+sudo systemctl show iriusrisk-docker | grep -i proxy
+```
+
+Check inside containers:
+
+```bash
+podman exec -it <container> env | grep -i proxy
+```
+
+or:
+
+```bash
+docker exec -it <container> env | grep -i proxy
+```
+
+---
+
+### ⚠️ Notes and Best Practices
+
+- Ensure your proxy allows access to:
+  - GitHub (github.com, raw.githubusercontent.com)
+  - Container registries (docker.io or your custom registry)
+  - OS package repositories
+- Include internal services in NO_PROXY:
+  localhost,127.0.0.1,postgres,jeff,redis
+- If using an external PostgreSQL database, include its host in NO_PROXY.
+
+---
+
+### 📌 Summary
+
+| Scenario | Action |
+|----------|--------|
+| No proxy | No action needed |
+| Proxy required | Export variables before running scripts |
+| Already deployed | Restart systemd service after updating env vars |
+
+---
+
+
 ### Fully Air-Gapped Environments
 
 If outbound internet access is not allowed, deployment can still be performed using offline mode. 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -104,6 +104,37 @@ function refresh_base_images() {
 	export POSTGRES_BASE_IMAGE REDIS_BASE_IMAGE
 }
 
+function add_proxy_env_args() {
+	local -n podman_args_ref="$1"
+	local proxy_var proxy_value
+
+	for proxy_var in \
+		HTTP_PROXY HTTPS_PROXY NO_PROXY \
+		http_proxy https_proxy no_proxy \
+		FTP_PROXY ftp_proxy ALL_PROXY all_proxy; do
+		proxy_value="${!proxy_var:-}"
+		if [[ -n $proxy_value ]]; then
+			podman_args_ref+=(--env "${proxy_var}=${proxy_value}")
+		fi
+	done
+}
+
+function systemd_proxy_env_lines() {
+	local proxy_var proxy_value out=""
+
+	for proxy_var in \
+		HTTP_PROXY HTTPS_PROXY NO_PROXY \
+		http_proxy https_proxy no_proxy \
+		FTP_PROXY ftp_proxy ALL_PROXY all_proxy; do
+		proxy_value="${!proxy_var:-}"
+		if [[ -n $proxy_value ]]; then
+			out+=$'\n'"Environment=${proxy_var}=${proxy_value}"
+		fi
+	done
+
+	printf '%s' "$out"
+}
+
 function prompt_registry_settings() {
 	if [ "${OFFLINE:-0}" -eq 1 ]; then
 		echo "Offline mode detected."
@@ -702,6 +733,7 @@ function build_podman_secret_image() {
 	local run_as_user="${7:-}"
 	local commit_cmd="${8:-}"
 	local wrapper_file final_exec_file
+	local -a podman_create_args=()
 
 	local original_entrypoint_json original_cmd_json original_entrypoint_exec original_user
 
@@ -774,8 +806,11 @@ EOF
 		printf '\nexec "$@"\n' >>"$wrapper_file"
 	fi
 
+	add_proxy_env_args podman_create_args
+
 	podman rm -f "$tmp_name" 2>/dev/null || true
 	podman create \
+		"${podman_create_args[@]}" \
 		--name "$tmp_name" \
 		--user root \
 		--entrypoint /bin/sh \
@@ -1381,6 +1416,8 @@ function detect_engine_ctx() {
 	NEED_DOCKER_CFG=""
 
 	local extra_registry_env=""
+	local proxy_env_lines
+	proxy_env_lines="$(systemd_proxy_env_lines)"
 	if [[ ${REGISTRY_URL:-docker.io} != "docker.io" || ${REGISTRY_NAMESPACE:-continuumsecurity/iriusrisk-prod} != "continuumsecurity/iriusrisk-prod" ]]; then
 		extra_registry_env=$'\nEnvironment=REGISTRY_URL='"${REGISTRY_URL}"$'\nEnvironment=REGISTRY_NAMESPACE='"${REGISTRY_NAMESPACE}"
 	fi
@@ -1394,7 +1431,7 @@ function detect_engine_ctx() {
 			SYSTEMCTL="sudo systemctl"
 			UNIT_AFTER=$'After=network.target docker.service'
 			UNIT_REQUIRES=$'Requires=docker.service'
-			UNIT_ENV_LINES=$'Environment=DOCKER_CONFIG=/etc/docker\nEnvironment=COMPOSE_INTERACTIVE_NO_CLI=1'"${extra_registry_env}"
+			UNIT_ENV_LINES=$'Environment=DOCKER_CONFIG=/etc/docker\nEnvironment=COMPOSE_INTERACTIVE_NO_CLI=1'"${extra_registry_env}${proxy_env_lines}"
 			NEED_DOCKER_CFG="true"
 			;;
 		podman)
@@ -1406,7 +1443,7 @@ function detect_engine_ctx() {
 			UNIT_AFTER=$'After=network-online.target
 Wants=network-online.target'
 			UNIT_REQUIRES=""
-			UNIT_ENV_LINES=$'Environment=PODMAN_SYSTEMD_UNIT=%n'"${extra_registry_env}"
+			UNIT_ENV_LINES=$'Environment=PODMAN_SYSTEMD_UNIT=%n'"${extra_registry_env}${proxy_env_lines}"
 			;;
 		*)
 			echo "Unknown engine '$ENGINE'." >&2


### PR DESCRIPTION
🌐 Add Proxy Support to Deployment Scripts

This PR introduces optional proxy support across the on-prem deployment automation, enabling installations in environments where outbound traffic must go through an HTTP/HTTPS proxy.

✅ What’s Included
1. Proxy Environment Variable Detection

The scripts now automatically detect standard proxy environment variables if they are set:

HTTP_PROXY, HTTPS_PROXY, NO_PROXY
Lowercase equivalents (http_proxy, etc.)
Optional: FTP_PROXY, ALL_PROXY

No changes are required for users who do not use a proxy.

2. Podman Image Build Support

Proxy variables are now passed into temporary containers used during:

Podman image customization (build_podman_secret_image)

This ensures package installs and image preparation steps work correctly behind a proxy.

3. Systemd Service Integration

Proxy variables are injected into generated systemd units:

Docker (iriusrisk-docker.service)
Podman (iriusrisk-podman.service)

This ensures all runtime containers inherit proxy configuration automatically.

4. Documentation Updates
Added a new “Proxy Configuration (Optional)” section to the README
Includes step-by-step setup instructions and verification guidance
🔁 Backward Compatibility
Fully backward-compatible
If no proxy variables are set, the deployment behaves exactly as before
No breaking changes to existing workflows
🧪 Testing Considerations

Tested scenarios:

✅ No proxy configured (baseline behavior unchanged)
✅ Proxy variables set → successful install and container runtime
✅ Podman image customization behind proxy
✅ Systemd services inherit proxy configuration correctly
📌 Summary

This change makes the deployment scripts compatible with restricted network environments while remaining completely transparent for standard installations.